### PR TITLE
Handle hmacgen crypto vector structure inside device file's private_data

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,0 +1,77 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in photon-checksum-generator project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at oss-coc@vmware.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq
+

--- a/README.md
+++ b/README.md
@@ -2,23 +2,35 @@
 
 # photon-checksum-generator
 
-## Overview
-
-## Try it out
+Photon-checksum-generator is used for generating hmac shasum(sha256/sha512) of a file.
 
 ### Prerequisites
 
-* Prereq 1
-* Prereq 2
-* Prereq 3
+In order to compile this project in Photon, linux-devel package is required.
 
 ### Build & Run
 
-1. Step 1
-2. Step 2
-3. Step 3
+To compile both user space and kernel modules from the checkout directory, run the following
 
-## Documentation
+```sh
+make all
+```
+
+You should have the userspace binary (hmacgen) under `user` folder, and kernel module (hmac\_generator.ko) under `kernel` folder.
+
+To load the kernel module, run following
+
+```sh
+cd kernel
+insmod hmac_generator.ko
+```
+
+To generate hmac-shasum for a file, use the built userspace binary as
+
+```sh
+cd user
+./hmacgen <HMAC-SHA256/HMAC-SHA512> <key> <path-to-the-file>
+```
 
 ## Contributing
 

--- a/include/hmac_gen.h
+++ b/include/hmac_gen.h
@@ -5,9 +5,26 @@
  * you may not use this file except in compliance with the License. The terms
  * of the License are located in the LICENSE file of this distribution.
  */
-
-int hmac_gen_crypto_module_init(struct device* hmac_gen_device);
-int hmac_gen_hash(hmacgen_out_data *user_data);
-int hmac_gen_set_key(unsigned char text_key[], int klen);
-int hmac_gen_set_algo(int algo, hmacgen_out_data *user_data);
-int hmac_gen_set_filepath(unsigned char path[]);
+#include "hmac_gen_ioctl.h"
+#define VECTOR_TYPE_SIZE 20
+typedef struct crypto_vector {
+        unsigned int algo;
+        unsigned int mask;
+        char vector_type[VECTOR_TYPE_SIZE];
+        int mode; //Encrypt=1 /Decrypt=2
+        int count;
+        int klen;
+        int data_tot_len;
+        int iv_len;
+        int rlen;
+        int olen;
+        unsigned char filepath[HMAC_MAX_FILEPATH_LEN];
+        unsigned char key[KEY_SIZE];
+        unsigned char *iv;
+        unsigned char *hash_input;
+        unsigned char hash_output[HMAC_MAX_OUT_LEN];
+} crypto_vector_t;
+int hmac_gen_hash(crypto_vector_t *crypto_data);
+int hmac_gen_set_key(crypto_vector_t *crypto_data, unsigned char text_key[], int klen);
+int hmac_gen_set_algo(crypto_vector_t *crypto_data, int algo);
+int hmac_gen_set_filepath(crypto_vector_t *crypto_data, unsigned char path[]);

--- a/include/hmac_gen_ioctl.h
+++ b/include/hmac_gen_ioctl.h
@@ -10,6 +10,7 @@
 #define DEVICE_NAME "hmac_gen"
 #define MAJOR_NUM 91
 #define KEY_SIZE 256
+#define HMAC_MAX_FILEPATH_LEN 1024
 #define HMAC_MAX_OUT_LEN 64
 
 // Crypto Algo Types
@@ -17,11 +18,6 @@ enum {
 	HMAC_SHA256 = 1,
 	HMAC_SHA512
 };
-
-typedef struct out_data {
-	int olen;
-	unsigned char hash_output[HMAC_MAX_OUT_LEN];
-}hmacgen_out_data;
 
 #define IOCTL_SET_KEY _IOW(MAJOR_NUM, 1, char *)
 #define IOCTL_SET_ALGO _IOW(MAJOR_NUM, 2, int *)

--- a/user/hmacgen.c
+++ b/user/hmacgen.c
@@ -19,7 +19,7 @@
 
 #include "hmac_gen_ioctl.h"
 #define IsNullOrEmptyString(str) (!(str) || !(*str))
-int hmac_fd;
+int hmac_fd = -1;
 static int olen = 0;
 static int hmacgen_read_hash(void);;
 static int hmacgen_driver_init(char *hmacgen_device);
@@ -66,6 +66,9 @@ int main(int argc, char **argv)
 		goto cleanup;
 	}
 cleanup:
+	if (hmac_fd > 0) {
+		close(hmac_fd);
+	}
 	return ret;
 }
 
@@ -130,6 +133,7 @@ static int hmacgen_set_filepath(char *filepath)
 {
 	int ret = -1;
 	struct stat file_stats;
+	char file_path[HMAC_MAX_FILEPATH_LEN] = {0};
 
 	if(IsNullOrEmptyString(filepath)) {
 		fprintf(stderr, "Null or empty file path\n");
@@ -149,7 +153,8 @@ static int hmacgen_set_filepath(char *filepath)
 		fprintf(stderr, "File size is zero\n");
 		return ret;
 	}
-	ret = ioctl(hmac_fd, IOCTL_SET_FILEPATH, filepath);
+	strncpy(file_path, filepath, strlen(filepath));
+	ret = ioctl(hmac_fd, IOCTL_SET_FILEPATH, file_path);
 	if (ret < 0) {
 		fprintf(stderr, "Error setting the file path to hmac_gen driver\n");
 	}


### PR DESCRIPTION
Changes include:

1. Adding README and CODE-OF-CONDUCT
2. Make the kernel's hmacgen crypto vector data structure as file's private_data to handle parallel operations from userspace.