### PR TITLE
Fix sg_init_buf failure for vmalloc'ed buffer

### DIFF
--- a/kernel/drv_hmac_gen.c
+++ b/kernel/drv_hmac_gen.c
@@ -186,7 +186,6 @@ static void __exit hmac_gen_exit(void)
 {
 	printk(KERN_INFO "Leaving HMAC gen\n");
 	device_destroy(hmac_gen_class, MKDEV(major_num, 0));
-	class_unregister(hmac_gen_class);
 	class_destroy(hmac_gen_class);
 	unregister_chrdev(major_num, DEVICE_NAME);
 }


### PR DESCRIPTION
Fixes include:
1. With CONFIG_DEBUG_SG enabled  sg_set_buf() checks whether the buffer passed
has a valid virtual address. If the buffer passed is allocated by vmalloc,
this will fail. Fix is to check if the buffer is allocated using vmalloc and
convert the vmalloc'ed address to page and use sg_set_page() to populate sg table.

2. Remove class_unregister as this is not required without class_register().